### PR TITLE
Avoid timestep scalar graph breaks during causal inference

### DIFF
--- a/pipeline/causal_diffusion_inference.py
+++ b/pipeline/causal_diffusion_inference.py
@@ -5,6 +5,7 @@ import torch
 from wan.utils.fm_solvers import FlowDPMSolverMultistepScheduler, get_sampling_sigmas, retrieve_timesteps
 from wan.utils.fm_solvers_unipc import FlowUniPCMultistepScheduler
 from utils.wan_wrapper import WanDiffusionWrapper, WanTextEncoder, WanVAEWrapper
+from utils.timestep import is_zero_timestep
 
 
 class CausalDiffusionInferencePipeline(torch.nn.Module):
@@ -140,7 +141,8 @@ class CausalDiffusionInferencePipeline(torch.nn.Module):
                     kv_cache=self.kv_cache_pos,
                     crossattn_cache=self.crossattn_cache_pos,
                     current_start=current_start_frame * self.frame_seq_length,
-                    cache_start=cache_start_frame * self.frame_seq_length
+                    cache_start=cache_start_frame * self.frame_seq_length,
+                    timestep_is_zero=True,
                 )
                 self.generator(
                     noisy_image_or_video=initial_latent[:, :1],
@@ -149,7 +151,8 @@ class CausalDiffusionInferencePipeline(torch.nn.Module):
                     kv_cache=self.kv_cache_neg,
                     crossattn_cache=self.crossattn_cache_neg,
                     current_start=current_start_frame * self.frame_seq_length,
-                    cache_start=cache_start_frame * self.frame_seq_length
+                    cache_start=cache_start_frame * self.frame_seq_length,
+                    timestep_is_zero=True,
                 )
                 current_start_frame += 1
                 cache_start_frame += 1
@@ -169,7 +172,8 @@ class CausalDiffusionInferencePipeline(torch.nn.Module):
                     kv_cache=self.kv_cache_pos,
                     crossattn_cache=self.crossattn_cache_pos,
                     current_start=current_start_frame * self.frame_seq_length,
-                    cache_start=cache_start_frame * self.frame_seq_length
+                    cache_start=cache_start_frame * self.frame_seq_length,
+                    timestep_is_zero=True,
                 )
                 self.generator(
                     noisy_image_or_video=current_ref_latents,
@@ -178,7 +182,8 @@ class CausalDiffusionInferencePipeline(torch.nn.Module):
                     kv_cache=self.kv_cache_neg,
                     crossattn_cache=self.crossattn_cache_neg,
                     current_start=current_start_frame * self.frame_seq_length,
-                    cache_start=cache_start_frame * self.frame_seq_length
+                    cache_start=cache_start_frame * self.frame_seq_length,
+                    timestep_is_zero=True,
                 )
                 current_start_frame += self.num_frame_per_block
                 cache_start_frame += self.num_frame_per_block
@@ -195,6 +200,7 @@ class CausalDiffusionInferencePipeline(torch.nn.Module):
             # Step 3.1: Spatial denoising loop
             sample_scheduler = self._initialize_sample_scheduler(noise)
             for _, t in enumerate(tqdm(sample_scheduler.timesteps)):
+                timestep_is_zero = is_zero_timestep(t)
                 latent_model_input = latents
                 timestep = t * torch.ones(
                     [batch_size, current_num_frames], device=noise.device, dtype=torch.float32
@@ -207,7 +213,8 @@ class CausalDiffusionInferencePipeline(torch.nn.Module):
                     kv_cache=self.kv_cache_pos,
                     crossattn_cache=self.crossattn_cache_pos,
                     current_start=current_start_frame * self.frame_seq_length,
-                    cache_start=cache_start_frame * self.frame_seq_length
+                    cache_start=cache_start_frame * self.frame_seq_length,
+                    timestep_is_zero=timestep_is_zero,
                 )
                 flow_pred_uncond, _ = self.generator(
                     noisy_image_or_video=latent_model_input,
@@ -216,7 +223,8 @@ class CausalDiffusionInferencePipeline(torch.nn.Module):
                     kv_cache=self.kv_cache_neg,
                     crossattn_cache=self.crossattn_cache_neg,
                     current_start=current_start_frame * self.frame_seq_length,
-                    cache_start=cache_start_frame * self.frame_seq_length
+                    cache_start=cache_start_frame * self.frame_seq_length,
+                    timestep_is_zero=timestep_is_zero,
                 )
 
                 flow_pred = flow_pred_uncond + self.args.guidance_scale * (
@@ -242,7 +250,8 @@ class CausalDiffusionInferencePipeline(torch.nn.Module):
                 kv_cache=self.kv_cache_pos,
                 crossattn_cache=self.crossattn_cache_pos,
                 current_start=current_start_frame * self.frame_seq_length,
-                cache_start=cache_start_frame * self.frame_seq_length
+                cache_start=cache_start_frame * self.frame_seq_length,
+                timestep_is_zero=True,
             )
             self.generator(
                 noisy_image_or_video=latents,
@@ -251,7 +260,8 @@ class CausalDiffusionInferencePipeline(torch.nn.Module):
                 kv_cache=self.kv_cache_neg,
                 crossattn_cache=self.crossattn_cache_neg,
                 current_start=current_start_frame * self.frame_seq_length,
-                cache_start=cache_start_frame * self.frame_seq_length
+                cache_start=cache_start_frame * self.frame_seq_length,
+                timestep_is_zero=True,
             )
 
             # Step 3.4: update the start and end frame indices

--- a/pipeline/causal_inference.py
+++ b/pipeline/causal_inference.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 import torch
 
 from utils.wan_wrapper import WanDiffusionWrapper, WanTextEncoder, WanVAEWrapper
+from utils.timestep import is_zero_timestep
 
 from utils.memory import gpu, get_cuda_free_memory_gb, DynamicSwapInstaller, move_model_to_device_with_memory_preservation
 
@@ -147,6 +148,7 @@ class CausalInferencePipeline(torch.nn.Module):
                     kv_cache=self.kv_cache1,
                     crossattn_cache=self.crossattn_cache,
                     current_start=current_start_frame * self.frame_seq_length,
+                    timestep_is_zero=True,
                 )
                 current_start_frame += 1
             else:
@@ -165,6 +167,7 @@ class CausalInferencePipeline(torch.nn.Module):
                     kv_cache=self.kv_cache1,
                     crossattn_cache=self.crossattn_cache,
                     current_start=current_start_frame * self.frame_seq_length,
+                    timestep_is_zero=True,
                 )
                 current_start_frame += self.num_frame_per_block
 
@@ -186,6 +189,7 @@ class CausalInferencePipeline(torch.nn.Module):
 
             # Step 3.1: Spatial denoising loop
             for index, current_timestep in enumerate(self.denoising_step_list):
+                timestep_is_zero = is_zero_timestep(current_timestep)
                 # set current timestep
                 timestep = torch.ones(
                     [batch_size, current_num_frames],
@@ -199,7 +203,8 @@ class CausalInferencePipeline(torch.nn.Module):
                         timestep=timestep,
                         kv_cache=self.kv_cache1,
                         crossattn_cache=self.crossattn_cache,
-                        current_start=current_start_frame * self.frame_seq_length
+                        current_start=current_start_frame * self.frame_seq_length,
+                        timestep_is_zero=timestep_is_zero,
                     )
                     next_timestep = self.denoising_step_list[index + 1]
                     noisy_input = self.scheduler.add_noise(
@@ -216,7 +221,8 @@ class CausalInferencePipeline(torch.nn.Module):
                         timestep=timestep,
                         kv_cache=self.kv_cache1,
                         crossattn_cache=self.crossattn_cache,
-                        current_start=current_start_frame * self.frame_seq_length
+                        current_start=current_start_frame * self.frame_seq_length,
+                        timestep_is_zero=timestep_is_zero,
                     )
 
             # Step 3.2: record the model's output
@@ -231,6 +237,7 @@ class CausalInferencePipeline(torch.nn.Module):
                 kv_cache=self.kv_cache1,
                 crossattn_cache=self.crossattn_cache,
                 current_start=current_start_frame * self.frame_seq_length,
+                timestep_is_zero=is_zero_timestep(self.args.context_noise),
             )
 
             if profile:

--- a/tests/test_timestep.py
+++ b/tests/test_timestep.py
@@ -1,0 +1,37 @@
+import unittest
+
+from utils.timestep import is_zero_timestep
+
+
+class FakeScalar:
+    def __init__(self, value):
+        self.value = value
+        self.item_calls = 0
+
+    def item(self):
+        self.item_calls += 1
+        return self.value
+
+
+class IsZeroTimestepTest(unittest.TestCase):
+    def test_python_scalars(self):
+        self.assertTrue(is_zero_timestep(0))
+        self.assertTrue(is_zero_timestep(0.0))
+        self.assertFalse(is_zero_timestep(1))
+        self.assertFalse(is_zero_timestep(0.5))
+
+    def test_tensor_like_scalar_is_extracted_once(self):
+        timestep = FakeScalar(0)
+
+        self.assertTrue(is_zero_timestep(timestep))
+        self.assertEqual(timestep.item_calls, 1)
+
+    def test_nonzero_tensor_like_scalar(self):
+        timestep = FakeScalar(999.0)
+
+        self.assertFalse(is_zero_timestep(timestep))
+        self.assertEqual(timestep.item_calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_timestep_plumbing.py
+++ b/tests/test_timestep_plumbing.py
@@ -1,0 +1,59 @@
+import ast
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TimestepPlumbingTest(unittest.TestCase):
+    def test_causal_pipeline_model_calls_pass_host_decision(self):
+        for relative_path in (
+            "pipeline/causal_inference.py",
+            "pipeline/causal_diffusion_inference.py",
+        ):
+            tree = ast.parse((ROOT / relative_path).read_text())
+            generator_calls = [
+                node
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "self"
+                and node.func.attr == "generator"
+            ]
+
+            self.assertTrue(generator_calls, relative_path)
+            for call in generator_calls:
+                keywords = {keyword.arg for keyword in call.keywords}
+                self.assertIn("timestep_is_zero", keywords, relative_path)
+
+    def test_compiled_model_path_has_no_unconditional_item_call(self):
+        tree = ast.parse((ROOT / "wan/modules/causal_model.py").read_text())
+        inference = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "_forward_inference"
+        )
+        item_calls = [
+            node
+            for node in ast.walk(inference)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "item"
+        ]
+
+        self.assertEqual(len(item_calls), 1)
+        fallback = next(
+            node
+            for node in inference.body
+            if isinstance(node, ast.If)
+            and isinstance(node.test, ast.Compare)
+            and isinstance(node.test.left, ast.Name)
+            and node.test.left.id == "timestep_is_zero"
+        )
+        self.assertIn(item_calls[0], list(ast.walk(fallback)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/timestep.py
+++ b/utils/timestep.py
@@ -1,0 +1,15 @@
+"""Helpers for decisions that must stay outside compiled model graphs."""
+
+
+def is_zero_timestep(timestep) -> bool:
+    """Return whether a scalar timestep is zero as a host-side boolean.
+
+    Inference pipelines call this before entering the diffusion model.  Keeping
+    scalar extraction at that boundary prevents ``Tensor.item()`` from breaking
+    a compiled model graph while preserving the existing zero-timestep
+    semantics.
+    """
+
+    item = getattr(timestep, "item", None)
+    value = item() if item is not None else timestep
+    return bool(value == 0)

--- a/utils/wan_wrapper.py
+++ b/utils/wan_wrapper.py
@@ -9,6 +9,7 @@ from wan.modules.model import WanModel, RegisterTokens, GanAttentionBlock
 from wan.modules.vae import _video_vae
 from wan.modules.t5 import umt5_xxl
 from wan.modules.causal_model import CausalWanModel
+from utils.timestep import is_zero_timestep
 
 
 class WanTextEncoder(torch.nn.Module):
@@ -225,7 +226,8 @@ class WanDiffusionWrapper(torch.nn.Module):
         concat_time_embeddings: Optional[bool] = False,
         clean_x: Optional[torch.Tensor] = None,
         aug_t: Optional[torch.Tensor] = None,
-        cache_start: Optional[int] = None
+        cache_start: Optional[int] = None,
+        timestep_is_zero: Optional[bool] = None,
     ) -> torch.Tensor:
         prompt_embeds = conditional_dict["prompt_embeds"]
 
@@ -238,6 +240,11 @@ class WanDiffusionWrapper(torch.nn.Module):
         logits = None
         # X0 prediction
         if kv_cache is not None:
+            if timestep_is_zero is None:
+                # Backward compatibility for callers outside the bundled
+                # pipelines. Internal pipelines extract this before entering
+                # the model so compiled graphs never execute Tensor.item().
+                timestep_is_zero = is_zero_timestep(timestep[0, 0])
             flow_pred = self.model(
                 noisy_image_or_video.permute(0, 2, 1, 3, 4),
                 t=input_timestep, context=prompt_embeds,
@@ -245,7 +252,8 @@ class WanDiffusionWrapper(torch.nn.Module):
                 kv_cache=kv_cache,
                 crossattn_cache=crossattn_cache,
                 current_start=current_start,
-                cache_start=cache_start
+                cache_start=cache_start,
+                timestep_is_zero=timestep_is_zero,
             ).permute(0, 2, 1, 3, 4)
         else:
             if clean_x is not None:

--- a/wan/modules/causal_model.py
+++ b/wan/modules/causal_model.py
@@ -772,7 +772,8 @@ class CausalWanModel(ModelMixin, ConfigMixin):
         kv_cache: dict = None,
         crossattn_cache: dict = None,
         current_start: int = 0,
-        cache_start: int = 0
+        cache_start: int = 0,
+        timestep_is_zero: bool = None,
     ):
         r"""
         Run the diffusion model with kv caching.
@@ -846,6 +847,11 @@ class CausalWanModel(ModelMixin, ConfigMixin):
             context = torch.concat([context_clip, context], dim=1)
 
         # arguments
+        if timestep_is_zero is None:
+            # Preserve the direct-model API. Bundled inference pipelines pass
+            # a host boolean and skip this graph-breaking compatibility path.
+            timestep_is_zero = t[0, 0].item() == 0
+
         kwargs = dict(
             e=e0,
             seq_lens=seq_lens,
@@ -853,7 +859,7 @@ class CausalWanModel(ModelMixin, ConfigMixin):
             freqs=self.freqs,
             context=context,
             context_lens=context_lens,
-            timestep=t[0,0].item(),
+            timestep=0 if timestep_is_zero else 1,
             block_mask=self.block_mask
         )
 


### PR DESCRIPTION
## Summary

- compute the zero-timestep decision in the Python inference loops before entering the diffusion model
- pass the host boolean through `WanDiffusionWrapper` into `CausalWanModel` so compiled inference does not execute `t[0, 0].item()`
- keep a compatibility fallback for direct/external model callers

## Why

`CausalWanModel._forward_inference` currently extracts the timestep with `Tensor.item()` on every model invocation. Under `torch.compile`/TorchDynamo this produces a repeated graph break and device-to-host synchronization. The bundled causal pipelines already own the Python timestep loop, so they can extract this scalar once outside the compiled model boundary (and reuse it for conditional/unconditional passes).

This preserves the existing rolling-sink condition exactly: zero timesteps still enable the sink refresh; nonzero timesteps do not.

## Validation

- `python3 -m compileall -q pipeline utils wan tests`
- `python3 -m unittest discover -s tests -v` (5 passed)
- `ruff check utils/timestep.py tests`
- `git diff --check`

The compatibility fallback is intentionally retained for callers that invoke `WanDiffusionWrapper` or `CausalWanModel` directly without the new optional flag.